### PR TITLE
fix load id split

### DIFF
--- a/lib/hmr.ts
+++ b/lib/hmr.ts
@@ -146,10 +146,9 @@ export function hmr(enableViteHmrForModes: string[] = ['development']): Plugin {
     },
     async load(id: string) {
       if (id.startsWith(virtualPrefix)) {
-        let [imp, specifier] = id
-          .split('?')[0]!
-          .slice(virtualPrefix.length, -'.gts'.length)
-          .split('::');
+        let [id2, specifier] = id.slice(virtualPrefix.length, -'.gts'.length).split('::');
+        let imp = id2!.split('?')[0];
+
         imp = imp!.replace('embroider_virtual', '@embroider/virtual');
         let filename = imp!;
         if (filename.includes('__vpc__')) {


### PR DESCRIPTION
id split in hmr's load function seems to be broken:

E.g. for 
`id = '/ember-vite-hmr/virtual/component:/@fs/P:/Project/node_modules/.vite/deps/ember-bootstrap_components_bs-dropdown.js?v=4dded479::default.gjs';`

before this PR:
```
        imp = '/@fs/P:/Project/node_modules/.vite/deps/ember-bootstrap_components_bs-dropdow';
        specifier = undefined;
```
after this PR:
```
        id2 = '/@fs/P:/Project/node_modules/.vite/deps/ember-bootstrap_components_bs-dropdown.js?v=4dded479';
        imp = '/@fs/P:/Project/node_modules/.vite/deps/ember-bootstrap_components_bs-dropdown.js';
        specifier = 'default';        
```

second reload still keeps failing due to `ERR_ABORTED 504 (Outdated Optimize Dep)` errors, but not sure if that is related to this plugin and is not just vite's problem.