### PR TITLE
fix: pass owner to service instances for proper dependency injection …

### DIFF
--- a/lib/babel-plugin.ts
+++ b/lib/babel-plugin.ts
@@ -301,10 +301,10 @@ export default function hotReplaceAst(babel: typeof Babel): PluginObj {
               false,
               true,
             ),
-            // @tracked _delegate = new _OriginalServiceImpl()
+            // @tracked _delegate
             t.classProperty(
               t.identifier('_delegate'),
-              t.newExpression(t.identifier(implVarName), []),
+              null,
               null,
               [t.decorator(tracked)],
               false,
@@ -320,6 +320,37 @@ export default function hotReplaceAst(babel: typeof Babel): PluginObj {
                   t.callExpression(t.super(), [
                     t.spreadElement(t.identifier('args')),
                   ]),
+                ),
+                // Store owner for HMR reloads
+                t.expressionStatement(
+                  t.assignmentExpression(
+                    '=',
+                    t.memberExpression(
+                      t.thisExpression(),
+                      t.identifier('_owner')
+                    ),
+                    t.memberExpression(
+                      t.identifier('args'),
+                      t.numericLiteral(0),
+                      true
+                    )
+                  )
+                ),
+                // Initialize delegate with owner
+                t.expressionStatement(
+                  t.assignmentExpression(
+                    '=',
+                    t.memberExpression(
+                      t.thisExpression(),
+                      t.identifier('_delegate')
+                    ),
+                    t.newExpression(t.identifier(implVarName), [
+                      t.memberExpression(
+                        t.thisExpression(),
+                        t.identifier('_owner')
+                      )
+                    ])
+                  )
                 ),
                 t.ifStatement(
                   t.unaryExpression('!', t.identifier(proxyVarName)),
@@ -486,7 +517,7 @@ export default function hotReplaceAst(babel: typeof Babel): PluginObj {
                 
                 const oldDelegate = ${proxyVarName}._delegate;
                 ${implVarName} = NewImpl;
-                const newDelegate = new ${implVarName}();
+                const newDelegate = new ${implVarName}(${proxyVarName}._owner);
                 ${proxyVarName}._delegate = newDelegate;
                 
                 // Sync state from old to new while keeping new implementation defaults

--- a/tests/playground/hmr.test.ts
+++ b/tests/playground/hmr.test.ts
@@ -578,7 +578,7 @@ export default class DataService extends Service {
   @service logger;
   @tracked value = 'updated';
 
-  getValue() {
+  get getValue() {
     return this.logger.log(this.value);
   }
 }

--- a/tests/playground/hmr.test.ts
+++ b/tests/playground/hmr.test.ts
@@ -513,6 +513,84 @@ export default class CounterService extends Service {
       expect(bodyContent).toContain('Count: 0'); // State preserved!
       expect(bodyContent).toContain('Message: v2 - updated'); // New default value
     });
+
+    test('should hmr services with injected dependencies', async () => {
+      // Create a logger service that will be injected
+      await editFile('./app/services/logger.js').setContent(`
+import Service from '@ember/service';
+
+export default class LoggerService extends Service {
+  log(message) {
+    return 'Logger v1: ' + message;
+  }
+}
+`);
+
+      // Create a data service that depends on logger
+      await editFile('./app/services/data.js').setContent(`
+import Service from '@ember/service';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class DataService extends Service {
+  @service logger;
+  @tracked value = 'initial';
+
+  getValue() {
+    return this.logger.log(this.value);
+  }
+}
+`);
+
+      // Create a component that uses the data service
+      await editFile('./app/components/test-component.gjs').setContent(`
+import Component from "@glimmer/component";
+import { service } from '@ember/service';
+
+export default class MyComponent extends Component {
+  @service data;
+
+  <template>
+    <div class='service-injection-hmr'>
+      {{this.data.getValue}}
+    </div>
+  </template>
+}
+`);
+
+      await waitForMessage('hot updated: /app/components/test-component.gjs');
+
+      // Wait for services to be injected
+      await new Promise(resolve => setTimeout(resolve, 1000));
+      
+      let body = await page.waitForSelector('.service-injection-hmr');
+      let bodyContent = await body.evaluate((el) => el.textContent);
+      
+      expect(bodyContent).toContain('Logger v1: initial');
+
+      // Update the data service - change the value
+      await editFile('./app/services/data.js').setContent(`
+import Service from '@ember/service';
+import { service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
+
+export default class DataService extends Service {
+  @service logger;
+  @tracked value = 'updated';
+
+  getValue() {
+    return this.logger.log(this.value);
+  }
+}
+`);
+
+      await waitForMessage(/hot updated:.*data\.js/);
+
+      // Verify the injected logger service still works after HMR
+      body = await page.waitForSelector('.service-injection-hmr');
+      bodyContent = await body.evaluate((el) => el.textContent);
+      expect(bodyContent).toContain('Logger v1: initial'); // State preserved!
+    });
   },
   120 * 1000,
 );

--- a/tests/playground/hmr.test.ts
+++ b/tests/playground/hmr.test.ts
@@ -536,7 +536,7 @@ export default class DataService extends Service {
   @service logger;
   @tracked value = 'initial';
 
-  getValue() {
+  get getValue() {
     return this.logger.log(this.value);
   }
 }

--- a/tests/service-hmr.test.js
+++ b/tests/service-hmr.test.js
@@ -93,9 +93,11 @@ export default TestService;
           [_init__delegate] = _applyDecs2203R(this, [[tracked, 0, "_delegate"]], []).e;
         }
         static Impl = TestService;
-        _delegate = _init__delegate(this, new _TestServiceImpl());
+        _delegate = _init__delegate(this);
         constructor(...args) {
           super(...args);
+          this._owner = args[0];
+          this._delegate = new _TestServiceImpl(this._owner);
           if (!_TestServiceProxy) {
             _TestServiceProxy = this;
           }
@@ -128,7 +130,7 @@ export default TestService;
           }
           const oldDelegate = _TestServiceProxy._delegate;
           _TestServiceImpl = NewImpl;
-          const newDelegate = new _TestServiceImpl();
+          const newDelegate = new _TestServiceImpl(_TestServiceProxy._owner);
           _TestServiceProxy._delegate = newDelegate;
           for (const key in oldDelegate) {
             const descriptor = Object.getOwnPropertyDescriptor(oldDelegate, key) || Object.getOwnPropertyDescriptor(Object.getPrototypeOf(oldDelegate), key);
@@ -308,9 +310,11 @@ export default class DataService extends Service {
           [_init__delegate] = _applyDecs2203R(this, [[tracked, 0, "_delegate"]], []).e;
         }
         static Impl = _DataService;
-        _delegate = _init__delegate(this, new _DataServiceImpl());
+        _delegate = _init__delegate(this);
         constructor(...args) {
           super(...args);
+          this._owner = args[0];
+          this._delegate = new _DataServiceImpl(this._owner);
           if (!_DataServiceProxy) {
             _DataServiceProxy = this;
           }
@@ -343,7 +347,7 @@ export default class DataService extends Service {
           }
           const oldDelegate = _DataServiceProxy._delegate;
           _DataServiceImpl = NewImpl;
-          const newDelegate = new _DataServiceImpl();
+          const newDelegate = new _DataServiceImpl(_DataServiceProxy._owner);
           _DataServiceProxy._delegate = newDelegate;
           for (const key in oldDelegate) {
             const descriptor = Object.getOwnPropertyDescriptor(oldDelegate, key) || Object.getOwnPropertyDescriptor(Object.getPrototypeOf(oldDelegate), key);


### PR DESCRIPTION
…in HMR

- Modified babel-plugin.ts to store owner in proxy constructor
- Pass owner when creating delegate instances (initial and HMR reload)
- Added test case for services with injected dependencies
- Updated snapshots to reflect owner parameter changes

Fixes issue where services with @service injections would fail with 'Attempting to lookup an injected property on an object without a container'