### PR TITLE
fix: detect app entry for HMR by its compat-modules import, not its path

### DIFF
--- a/lib/hmr.ts
+++ b/lib/hmr.ts
@@ -303,16 +303,18 @@ export function hmr(enableViteHmrForModes: string[] = ['development']): Plugin {
       if (compatModulesImport) {
         const compatModules = compatModulesImport[1];
         source += `\n
-              let prevCompatModules = Object.assign({}, ${compatModules});
-              import.meta.hot.accept('${compatModulesSpecifier}', (m) => {
-                for (const [name, module] of Object.entries(m.default)) {
-                  ${compatModules}[name] = module;
-                  if (name.includes('initializers') && prevCompatModules[name]?.default !== module.default) {
-                    globalThis.location.reload();
+              if (import.meta.hot) {
+                let prevCompatModules = Object.assign({}, ${compatModules});
+                import.meta.hot.accept('${compatModulesSpecifier}', (m) => {
+                  for (const [name, module] of Object.entries(m.default)) {
+                    ${compatModules}[name] = module;
+                    if (name.includes('initializers') && prevCompatModules[name]?.default !== module.default) {
+                      globalThis.location.reload();
+                    }
                   }
-                }
-                prevCompatModules = m.default;
-              })`;
+                  prevCompatModules = m.default;
+                });
+              }`;
       }
       if (resourcePath.includes('ember-vite-hmr/virtual/components')) {
         return source;

--- a/lib/hmr.ts
+++ b/lib/hmr.ts
@@ -128,6 +128,11 @@ function normalizePath(inputPath: string): string {
 
 const virtualPrefix = '/ember-vite-hmr/virtual/component:';
 
+// Embroider's resolver registry. It's the binding the app entry's HMR hook
+// mutates, so we use it to locate that entry. Embroider keeps this as an
+// internal literal (not a public export), so we mirror the string here.
+const compatModulesSpecifier = '@embroider/virtual/compat-modules';
+
 export function hmr(enableViteHmrForModes: string[] = ['development']): Plugin {
   // let conf: any;
   let server: ViteDevServer;
@@ -286,15 +291,22 @@ export function hmr(enableViteHmrForModes: string[] = ['development']): Plugin {
       if (!supportedExt.some((x) => resourcePath.endsWith(x))) {
         return source;
       }
-      const pkgPath = path.resolve(process.cwd(), 'package.json');
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const name = require(pkgPath).name;
-      if (resourcePath.includes(`${name}/app/app.js`)) {
+      // Wire compat-modules HMR into the app entry, detected by the
+      // compat-modules import it owns rather than its path.
+      const compatModulesImport =
+        !resourcePath.includes('node_modules') &&
+        source.match(
+          new RegExp(
+            `import\\s+(\\w+)\\s+from\\s+['"]${compatModulesSpecifier}['"]`,
+          ),
+        );
+      if (compatModulesImport) {
+        const compatModules = compatModulesImport[1];
         source += `\n
-              let prevCompatModules = Object.assign({}, compatModules);
-              import.meta.hot.accept('@embroider/virtual/compat-modules', (m) => {
+              let prevCompatModules = Object.assign({}, ${compatModules});
+              import.meta.hot.accept('${compatModulesSpecifier}', (m) => {
                 for (const [name, module] of Object.entries(m.default)) {
-                  compatModules[name] = module;
+                  ${compatModules}[name] = module;
                   if (name.includes('initializers') && prevCompatModules[name]?.default !== module.default) {
                     globalThis.location.reload();
                   }

--- a/tests/hmr-transform.test.ts
+++ b/tests/hmr-transform.test.ts
@@ -244,6 +244,27 @@ export const __hmr_import_metadata__ = {
     process.env.EMBER_VITE_HMR_ENABLED = 'true';
   });
 
+  it('wires compat-modules HMR into the entry by its import (TS entry, folder != package name)', async () => {
+    const source = `import compatModules from '@embroider/virtual/compat-modules';\n`;
+    const id = '/repo/packages/frontend/app/app.ts';
+    const result = await plugin.transform.call(mockContext, source, id);
+
+    expect(result).toContain(
+      "import.meta.hot.accept('@embroider/virtual/compat-modules'",
+    );
+    expect(result).toContain('compatModules[name] = module');
+  });
+
+  it('does not wire compat-modules HMR into modules that do not import it', async () => {
+    const source = `export default class App {}\n`;
+    const id = '/my-app/app/app.js';
+    const result = await plugin.transform.call(mockContext, source, id);
+
+    expect(result).not.toContain(
+      "import.meta.hot.accept('@embroider/virtual/compat-modules'",
+    );
+  });
+
   it('should handle @embroider/virtual imports', async () => {
     const source = `
 import Component from '@embroider/virtual/components/my-component';


### PR DESCRIPTION
The `app/app.js` HMR boundary (which accepts `@embroider/virtual/compat-modules`) is only injected when the app folder matches the package `name` and the entry is `.js`:

```js
if (resourcePath.includes(`${name}/app/app.js`)) { … }
```

So it misses monorepos (folder ≠ package `name`, e.g. `frontend` in `…/UI/frontend`) and TypeScript entries (`app/app.ts`). Without the boundary, every edit is a full page reload instead of HMR.

Fix: detect the entry by the `@embroider/virtual/compat-modules` import it owns (the binding the hook mutates), not its path — folder/extension-agnostic, and a no-op when that import is absent.

Repro: https://github.com/johanrd/ember-vite-hmr-repro

Cowritten by claude