### PR TITLE
Fix/guard hmr initializers in prod

### DIFF
--- a/src/instance-initializers/setup-hmr-manager.ts
+++ b/src/instance-initializers/setup-hmr-manager.ts
@@ -84,6 +84,10 @@ function syncState(instance: Mutable<HotComponent>) {
 }
 
 export function initialize() {
+  // HMR-only: in a production build `import.meta.hot` is undefined, so this
+  // (and the manager/route monkey-patches below) is dead-code-eliminated.
+  if (!import.meta.hot) return;
+
   const ComponentManager = getInternalComponentManager(Component);
   const proto = Object.getPrototypeOf(ComponentManager);
   const create = proto.create;

--- a/src/instance-initializers/vite-hot-reload.ts
+++ b/src/instance-initializers/vite-hot-reload.ts
@@ -1,5 +1,3 @@
-/// <reference types="../../types/global" />
-
 import ApplicationInstance from '@ember/application/instance';
 import { debounce, next } from '@ember/runloop';
 import RouterService from '@ember/routing/router-service';
@@ -69,6 +67,10 @@ function supportErrorRecovery(appInstance: ApplicationInstance) {
 }
 
 export function initialize(application: ApplicationInstance) {
+  // HMR-only: in a production build `import.meta.hot` is undefined, so the
+  // resolver patch and console.warn override below are dead-code-eliminated.
+  if (!import.meta.hot) return;
+
   patchResolver(application);
   supportErrorRecovery(application);
 }

--- a/src/services/vite-hot-reload.ts
+++ b/src/services/vite-hot-reload.ts
@@ -28,6 +28,9 @@ export default class ViteHotReloadService extends Service {
 
   init(args?: object) {
     super.init(args);
+    // HMR-only: `import.meta.hot` is undefined in production builds, so the
+    // resolver/router patching below is dead-code-eliminated there.
+    if (!import.meta.hot) return;
     if (!globalThis.emberHotReloadPlugin) return;
     const app = (getOwner(this) as ApplicationInstance)!.application as unknown as {
       Resolver: unknown;


### PR DESCRIPTION
The initializers were ungated; the service patching sat behind a runtime `globalThis` guard, so it shipped into prod even though it never ran.

### Repro
https://github.com/johanrd/ember-vite-hmr-repro/tree/prod-leak

```
pnpm install
pnpm build
grep -rE "unrecoverable error occur during render|--hot-version--" dist/assets
```

## Fix

Guard each `initialize()` and the service's `init()` with `if (!import.meta.hot) return;`. In a production build `import.meta.hot` is statically `undefined`, so the bundler dead-code-eliminates the bodies.

## Verification

Production build of a TypeScript app with the addon, before vs after:

| HMR patching in prod bundle | before | after |
| --- | --- | --- |
| `ComponentManager.create` | present | **gone** |
| `Route.setupController` | present | **gone** |
| `console.warn` override | present | **gone** |
| resolver `resolve` patch | present | **gone** |
| router `getRoute` / `--hot-version--` | present | **gone** |

Only an inert, near-empty service shell remains.

(Also drops a now-redundant triple-slash type reference; `import.meta.hot` is typed via `vite/client` in tsconfig.)


---

## Alternative considered: don't ship the runtime to prod at all

This PR makes the runtime **inert** in production (the bodies dead-code-eliminate), but the three modules are still listed in the addon's `ember-addon.app-js`, so Embroider merges them into every app and the empty shells (plus the two no-op `initialize()` calls at boot) remain in the production bundle.

A more thorough alternative is to **not** contribute the runtime via static `app-js`, and instead inject it dev-only through the Vite plugin — the same way `setup-ember-hmr.js` is already injected via `transformIndexHtml` (gated on `EMBER_VITE_HMR_ENABLED`). This is also how `@vitejs/plugin-react` keeps the refresh runtime out of prod (`apply: 'serve'` / `command !== 'build'` + virtual modules). The initializers/service would then be registered **programmatically** via the public `App.initializer` / `App.instanceInitializer` APIs, from a small helper the dev-only app-entry transform calls.

**Trade-off:**
- **Pro:** in a production build the addon contributes *nothing* — genuinely byte-clean (and makes a "prod build is unaffected by the plugin" regression test possible).
- **Con:** the dev transform injects ~2 lines into the app entry, which is slightly less idiomatic than `app-js`.

**Proof of concept:** with `app-js` emptied and registration moved into the dev-only transform, HMR still works on a fresh `@ember/app-blueprint` TS app (`[vite] hmr update`, no full reload). Because the runtime is then imported only from that dev-only transform, it drops out of production builds entirely.
