### PR TITLE
Fix route template HMR when vite base or https is configured

### DIFF
--- a/lib/hmr.ts
+++ b/lib/hmr.ts
@@ -140,7 +140,7 @@ const virtualPrefix = '/ember-vite-hmr/virtual/component:';
 const compatModulesSpecifier = '@embroider/virtual/compat-modules';
 
 export function hmr(enableViteHmrForModes: string[] = ['development']): Plugin {
-  // let conf: any;
+  let base = '/';
   let server: ViteDevServer;
   return {
     name: 'hmr-plugin',
@@ -174,7 +174,7 @@ export function hmr(enableViteHmrForModes: string[] = ['development']): Plugin {
       server = s;
     },
     configResolved(config) {
-      // conf = config;
+      base = config.base;
       process.env.EMBER_VITE_HMR_ENABLED = enableViteHmrForModes
         .includes(config.mode)
         .toString();
@@ -271,7 +271,9 @@ export function hmr(enableViteHmrForModes: string[] = ['development']): Plugin {
       if (process.env.EMBER_VITE_HMR_ENABLED !== 'true') {
         return html;
       }
-      const fullPath = '/@ember-vite-hmr/setup-ember-hmr.js';
+      // this hook runs after vite's own html transform, so the configured
+      // `base` has to be prefixed manually (it always ends with a slash)
+      const fullPath = `${base}@ember-vite-hmr/setup-ember-hmr.js`;
       return [
         {
           tag: 'script',
@@ -399,12 +401,22 @@ export function hmr(enableViteHmrForModes: string[] = ['development']): Plugin {
           local: string;
           source: string;
           specifier: string;
-        }> = [];        
+        }> = [];
 
         // First pass: Extract metadata
         traverse(result, {
           ExportNamedDeclaration(path: NodePath<{ declaration?: unknown }>) {
-            const declaration = (path.node as { declaration?: { type?: string; declarations?: Array<{ id?: { name?: string }; init?: unknown }> } }).declaration;
+            const declaration = (
+              path.node as {
+                declaration?: {
+                  type?: string;
+                  declarations?: Array<{
+                    id?: { name?: string };
+                    init?: unknown;
+                  }>;
+                };
+              }
+            ).declaration;
 
             // Check if this is: export const __hmr_import_metadata__ = {...}
             if (
@@ -412,7 +424,18 @@ export function hmr(enableViteHmrForModes: string[] = ['development']): Plugin {
               declaration.declarations?.[0]?.id?.name ===
                 '__hmr_import_metadata__'
             ) {
-              const init = declaration.declarations[0].init as { type?: string; properties?: Array<{ type?: string; key?: { type?: string; name?: string }; value?: { type?: string; value?: string; elements?: Array<{ type?: string; value?: string }> } }> };
+              const init = declaration.declarations[0].init as {
+                type?: string;
+                properties?: Array<{
+                  type?: string;
+                  key?: { type?: string; name?: string };
+                  value?: {
+                    type?: string;
+                    value?: string;
+                    elements?: Array<{ type?: string; value?: string }>;
+                  };
+                }>;
+              };
 
               if (init?.type === 'ObjectExpression') {
                 // Extract importVar and bindings from the object
@@ -462,7 +485,10 @@ export function hmr(enableViteHmrForModes: string[] = ['development']): Plugin {
                     // For named imports, use the imported name
                     // Handle both Identifier and StringLiteral types
                     const imported = specifier.imported;
-                    specifierName = imported.type === 'Identifier' ? imported.name : imported.value;
+                    specifierName =
+                      imported.type === 'Identifier'
+                        ? imported.name
+                        : imported.value;
                   } else if (specifier.type === 'ImportNamespaceSpecifier') {
                     specifierName = '*';
                   }

--- a/src/setup-ember-hmr.ts
+++ b/src/setup-ember-hmr.ts
@@ -1,5 +1,22 @@
 import type { Module } from '../types/global';
 
+function moduleIdFromUrl(moduleUrl: string) {
+  let id = moduleUrl.split('?')[0]!;
+  try {
+    // covers http/https and URLs without an explicit port
+    id = new URL(id).pathname;
+  } catch {
+    // not an absolute URL, keep as-is
+  }
+  // strip vite's `base` so ids are stable (`app/templates/...`) no matter
+  // what base the app is served under
+  const base = import.meta.env.BASE_URL || '/';
+  if (base !== '/' && id.startsWith(base)) {
+    id = id.slice(base.length);
+  }
+  return id.replace(/^\//, '');
+}
+
 if (import.meta.hot) {
   const ModuleMap = new Map();
 
@@ -46,7 +63,7 @@ if (import.meta.hot) {
       const m = await this.__import(moduleUrl);
       const module: Module = {
         exports: m,
-        id: moduleUrl.split('?')[0]!.replace(/http:\/\/.*:[^\/]*\//, ''),
+        id: moduleIdFromUrl(moduleUrl),
         version: 0,
       };
       this._accepting -= 1;

--- a/tests/playground/hmr.test.ts
+++ b/tests/playground/hmr.test.ts
@@ -524,17 +524,17 @@ export default class MyComponent extends Component {
 
       // Wait for component to render and service to be injected
       // The service needs time to be transformed by Babel and injected
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+
       let body = await page.waitForSelector('.service-hmr');
       let bodyContent = await body.evaluate((el) => el.textContent);
-      
+
       // If service values are not rendered yet, wait a bit more
       if (!bodyContent.includes('Count: 0')) {
-        await new Promise(resolve => setTimeout(resolve, 1000));
+        await new Promise((resolve) => setTimeout(resolve, 1000));
         bodyContent = await body.evaluate((el) => el.textContent);
       }
-      
+
       expect(bodyContent).toContain('Count: 0');
       expect(bodyContent).toContain('Message: v1');
 
@@ -557,7 +557,7 @@ export default class CounterService extends Service {
       await waitForMessage(/hot updated:.*counter\.js/);
 
       // Verify state was preserved (count should still be 0) but message updated
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      await new Promise((resolve) => setTimeout(resolve, 1000));
       body = await page.waitForSelector('.service-hmr');
       bodyContent = await body.evaluate((el) => el.textContent);
       expect(bodyContent).toContain('Count: 0'); // State preserved!
@@ -611,11 +611,11 @@ export default class MyComponent extends Component {
       await waitForMessage('hot updated: /app/components/test-component.gjs');
 
       // Wait for services to be injected
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
       let body = await page.waitForSelector('.service-injection-hmr');
       let bodyContent = await body.evaluate((el) => el.textContent);
-      
+
       expect(bodyContent).toContain('Logger v1: initial');
 
       // Update the data service - change the value
@@ -641,6 +641,62 @@ export default class DataService extends Service {
       bodyContent = await body.evaluate((el) => el.textContent);
       expect(bodyContent).toContain('Logger v1: initial'); // State preserved!
     });
+
+    // must stay the last test: it tears down the shared vite instance and
+    // boots a new one with a non-root `base`
+    test(
+      'should update route templates when vite base is set',
+      { timeout: 120 * 1000 },
+      async () => {
+        await viteContext.stop();
+
+        // ember's router only understands URLs under its rootURL, so it has
+        // to match the vite base for the app to boot at /my-app/
+        await editFile('./config/environment.js').replaceCode(
+          "rootURL: '/'",
+          "rootURL: '/my-app/'",
+        );
+        await editFile('./app/templates/application.hbs').setContent(
+          '<div class="base-route">base v1</div>',
+        );
+
+        try {
+          // a different port avoids colliding with the previous instance's
+          // socket while it is torn down
+          viteContext = await startVite({
+            cwd: appDir,
+            port: 60174,
+            basePath: '/my-app/',
+          });
+          page = viteContext.page;
+
+          const body = await page.waitForSelector('.base-route');
+          const bodyContent = await body.evaluate((el) => el.textContent);
+          expect(bodyContent, bodyContent).toContain('base v1');
+
+          // drop the boot logs so waitForMessage only sees the update
+          viteContext.messages.length = 0;
+
+          await editFile('./app/templates/application.hbs').setContent(
+            '<div class="base-route">base v2</div>',
+          );
+          await waitForMessage(
+            /hot updated:.*app\/templates\/application\.hbs/,
+          );
+          await page.waitForFunction(
+            () => document.body.textContent!.includes('base v2'),
+            undefined,
+            { timeout: 5000 },
+          );
+        } finally {
+          // keep the app reusable for REUSE runs
+          await editFile('./config/environment.js').replaceCode(
+            "rootURL: '/my-app/'",
+            "rootURL: '/'",
+          );
+        }
+      },
+    );
   },
   120 * 1000,
 );

--- a/tests/utils/index.ts
+++ b/tests/utils/index.ts
@@ -5,11 +5,12 @@ import { chromium } from 'playwright-chromium';
 export async function startVite({
   cwd,
   port = 60173,
+  basePath = '/',
 }: {
   cwd: string;
   port?: number;
+  basePath?: string;
 }) {
-
   globalThis.console.log('[ci] starting');
   const messages: string[] = [];
   let runvite: ReturnType<typeof child.fork>;
@@ -18,7 +19,13 @@ export async function startVite({
     globalThis.console.log('start vite');
     runvite = child.fork(
       resolve('.', 'node_modules', 'vite', 'bin', 'vite.js'),
-      ['--port', String(port), '--no-open', '--force'],
+      [
+        '--port',
+        String(port),
+        '--no-open',
+        '--force',
+        ...(basePath !== '/' ? ['--base', basePath] : []),
+      ],
       {
         stdio: 'pipe',
         cwd,
@@ -66,7 +73,7 @@ export async function startVite({
     const context = await browser.newContext();
     const page = await context.newPage();
     globalThis.console.log('load page');
-    await page.goto(`http://localhost:${port}`);
+    await page.goto(`http://localhost:${port}${basePath}`);
     page.on('console', (msg) => {
       globalThis.console.log(msg.text());
       messages.push(msg.text());
@@ -80,11 +87,24 @@ export async function startVite({
       runvite.stdout?.on('data', later);
     }
 
+    async function stop() {
+      await browser.close();
+      await new Promise<void>((fulfill) => {
+        if (runvite.exitCode !== null || runvite.killed) {
+          fulfill();
+          return;
+        }
+        runvite.on('exit', () => fulfill());
+        runvite.kill();
+      });
+    }
+
     return {
       page,
       onMessage,
       messages,
       baseUri: `http://localhost:${port}`,
+      stop,
     };
   } catch {
     await browser.close();


### PR DESCRIPTION
Fixes #498

## Problem

With `base: '/my-app/'` (and/or `https`) in vite config, editing a route template showed the update in the terminal and the network tab, but the page never refreshed.

## Root causes

Two independent bugs, both tied to how the plugin handles URLs:

1. **The setup script never loaded under a non-root `base`.** `transformIndexHtml` injected `import "/@ember-vite-hmr/setup-ember-hmr.js"` without the base prefix. Since this hook runs after vite's own html transform, the request bypassed vite's middleware entirely and `globalThis.emberHotReloadPlugin` was never installed in the browser — so no accept handlers were registered and the hot-reload service never subscribed. The base is now prefixed explicitly.

2. **Module ids kept the base prefix (and broke on https).** `canAcceptNew` derived ids via `moduleUrl.replace(/http:\/\/.*:[^\/]*\//, '')`, which left `https://` URLs (and hosts without an explicit port) untouched and left the base in the path, producing ids like `my-app/app/templates/application.hbs`. Those never matched the `app/templates/` checks in the hot-reload service that trigger `router.refresh()`. Ids are now derived from `new URL(...).pathname` with `import.meta.env.BASE_URL` stripped.

## Testing

New e2e test (`should update route templates when vite base is set`) boots the playground app with `--base /my-app/` (and a matching Ember `rootURL`), edits the route template, and asserts the DOM updates in place. Verified it fails without the fix and passes with it; full suite (10 tests) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)