### PR TITLE
Fix virtual component 404 for classic components under non-root base (#498)

### DIFF
--- a/lib/hmr.ts
+++ b/lib/hmr.ts
@@ -277,7 +277,16 @@ export function hmr(enableViteHmrForModes: string[] = ['development']): Plugin {
           /\bfrom\s*['"]([^'"]+\.hbs(?:\?[^'"]*)?)['"]/,
         );
         if (templateImportMatch) {
-          const templateSpecifier = templateImportMatch[1]!;
+          // The compiled backing class embeds the template import as a
+          // browser-facing URL (i.e. prefixed with the configured vite
+          // `base`), since that's what gets sent to the client. But
+          // `server.transformRequest` is an internal API keyed by root-
+          // relative ids, so the base has to be stripped back off before
+          // reusing that specifier here, or this 404s under a non-root base.
+          let templateSpecifier = templateImportMatch[1]!;
+          if (base !== '/' && templateSpecifier.startsWith(base)) {
+            templateSpecifier = `/${templateSpecifier.slice(base.length)}`;
+          }
           const templateRes = await server.transformRequest(templateSpecifier);
           yieldSourceFilename = templateSpecifier;
           yieldSourceContent = templateRes?.code;

--- a/tests/playground/hmr.test.ts
+++ b/tests/playground/hmr.test.ts
@@ -745,6 +745,9 @@ export default class DataService extends Service {
           });
           page = viteContext.page;
 
+          const pageErrors: string[] = [];
+          page.on('pageerror', (err) => pageErrors.push(String(err)));
+
           const body = await page.waitForSelector('.base-route');
           const bodyContent = await body.evaluate((el) => el.textContent);
           expect(bodyContent, bodyContent).toContain('base v1');
@@ -763,6 +766,40 @@ export default class DataService extends Service {
             undefined,
             { timeout: 5000 },
           );
+
+          // Reproduce #498: a classic component (separate backing class +
+          // template, going through Embroider's virtual pair-component
+          // pipeline) rendered under a non-root `base`.
+          await editFile('./app/components/base-paired-component.js')
+            .setContent(`
+    import Component from "@glimmer/component";
+
+    export default class BasePairedComponent extends Component {}
+    `);
+          await editFile(
+            './app/components/base-paired-component.hbs',
+          ).setContent(`<div class="base-paired-component">paired v1</div>`);
+          await editFile('./app/templates/application.hbs').setContent(`
+        <div class="base-route">base v2</div>
+        <BasePairedComponent />`);
+          await waitForMessage(
+            /hot updated:.*app\/templates\/application\.hbs/,
+          );
+          const paired = await page.waitForSelector('.base-paired-component');
+          const pairedContent = await paired.evaluate((el) => el.textContent);
+          expect(pairedContent, pairedContent).toContain('paired v1');
+
+          await editFile(
+            './app/components/base-paired-component.hbs',
+          ).setContent(`<div class="base-paired-component">paired v2</div>`);
+          await waitForMessage(/hot updated:.*base-paired-component/);
+          await page.waitForFunction(
+            () => document.body.textContent!.includes('paired v2'),
+            undefined,
+            { timeout: 5000 },
+          );
+
+          expect(pageErrors, pageErrors.join('\n')).toEqual([]);
         } finally {
           // keep the app reusable for REUSE runs
           await editFile('./config/environment.js').replaceCode(

--- a/tests/playground/hmr.test.ts
+++ b/tests/playground/hmr.test.ts
@@ -782,8 +782,14 @@ export default class DataService extends Service {
           await editFile('./app/templates/application.hbs').setContent(`
         <div class="base-route">base v2</div>
         <BasePairedComponent />`);
+          // BasePairedComponent is referenced here for the first time, so
+          // resolving it goes through Embroider's virtual pair-component
+          // pipeline cold (no prior module-graph entry) and may also trigger
+          // a dependency re-optimization pass; give it more room than the
+          // default 3s, as with the first `fn` import above.
           await waitForMessage(
             /hot updated:.*app\/templates\/application\.hbs/,
+            20 * 1000,
           );
           const paired = await page.waitForSelector('.base-paired-component');
           const pairedContent = await paired.evaluate((el) => el.textContent);


### PR DESCRIPTION
## Summary

Fixes the console errors reported in the [latest comment on #498](https://github.com/patricklx/ember-vite-hmr/issues/498): `Failed to fetch dynamically imported module` for every `embroider_virtual/components/...` component, only when vite `base` is configured to a non-root path.

## Root cause

The hot wrapper's `load()` hook, when handling a **classic component** (a separate backing class + `.hbs` template — no `.gjs`), re-fetches the compiled backing class via `server.transformRequest()` to find the template it imports (needed to detect named blocks). It then calls `server.transformRequest()` again on that extracted `.hbs` import specifier.

The compiled backing class embeds that specifier as a browser-facing URL, i.e. **prefixed with the configured vite `base`** (correct, since that's what gets shipped to the browser). But `server.transformRequest` is an *internal* Vite API keyed by root-relative ids — it has no concept of `base`. Passing it a base-prefixed path makes it look for a nonexistent file, throwing internally (`ERR_LOAD_URL`), which Vite's transform middleware silently swallows and falls through to the SPA `index.html` fallback. The browser then tries to execute that HTML as a JS module and throws `Failed to fetch dynamically imported module`.

This only reproduces for apps that use classic (non-strict-mode, no `.gjs`) components — matching the reporter's "I don't have any .gjs files in my app" — and only under a non-root `base`, since with the default root base there's no prefix to strip and the bug is invisible.

## Fix

Strip the configured `base` prefix off the extracted template specifier before reusing it with `server.transformRequest`.

## Test plan

- [x] Added a regression test in `tests/playground/hmr.test.ts` that renders a classic paired component (separate `.js` + `.hbs`) under a non-root `base`, asserts it hot-updates correctly, and asserts zero page errors — this reproduced the exact `Failed to fetch dynamically imported module` error before the fix, and passes after.
- [x] Full suite (`pnpm run test`, 34 tests across 6 files) passes.