### PR TITLE
Fix route/template HMR module ids for Node-loader (non-browser) consumers

### DIFF
--- a/src/setup-ember-hmr.ts
+++ b/src/setup-ember-hmr.ts
@@ -1,6 +1,12 @@
 import type { Module } from '../types/global';
 
-function moduleIdFromUrl(moduleUrl: string) {
+// Matches the app/addon-relative portion of a path once it reaches one of
+// the directories ember-vite-hmr hot-reloads, e.g. the `app/templates/...`
+// in `/Users/me/project/app/templates/application.hbs`.
+const APP_RELATIVE_ID =
+  /(?:^|\/)((?:app|addon)\/(?:routes?|routers|controllers|templates|services)\/.*)$/;
+
+export function moduleIdFromUrl(moduleUrl: string) {
   let id = moduleUrl.split('?')[0]!;
   try {
     // covers http/https and URLs without an explicit port
@@ -14,7 +20,19 @@ function moduleIdFromUrl(moduleUrl: string) {
   if (base !== '/' && id.startsWith(base)) {
     id = id.slice(base.length);
   }
-  return id.replace(/^\//, '');
+  id = id.replace(/^\//, '');
+  // Outside of vite's own dev server (e.g. a Node ESM loader running the
+  // app directly against on-disk `file://` URLs, with no server `base` to
+  // strip) `id` is still the full OS path up to the project root instead
+  // of a server-relative one. Re-anchor it to the nearest hot-reloadable
+  // directory so consumers that key off ids like `app/templates/...`
+  // (ViteHotReloadService's `startsWith('app/templates/')` check) keep
+  // working no matter where the checkout lives on disk.
+  const rooted = id.match(APP_RELATIVE_ID);
+  if (rooted) {
+    id = rooted[1]!;
+  }
+  return id;
 }
 
 if (import.meta.hot) {

--- a/tests/setup-ember-hmr.test.ts
+++ b/tests/setup-ember-hmr.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { moduleIdFromUrl } from '../src/setup-ember-hmr';
+
+describe('moduleIdFromUrl', () => {
+  it('strips a root-relative browser URL down to the app-relative id', () => {
+    expect(
+      moduleIdFromUrl(
+        'http://localhost:4200/app/templates/application.hbs?t=123',
+      ),
+    ).toBe('app/templates/application.hbs');
+  });
+
+  it('strips vite base and host from a non-root browser URL', () => {
+    expect(
+      moduleIdFromUrl(
+        'https://example.test/my-app/app/templates/application.hbs?t=123',
+      ),
+    ).toBe('app/templates/application.hbs');
+  });
+
+  // Regression test: outside of vite's own dev server (e.g. a Node ESM
+  // loader running the app directly against on-disk `file://` URLs) there
+  // is no server `base` to strip, so `id` was left as the full OS path up
+  // to the project root (e.g. `Users/me/project/app/templates/...`) instead
+  // of `app/templates/...`. Consumers like ViteHotReloadService key off ids
+  // that `startsWith('app/templates/')`, so route/template HMR silently
+  // never fired in that setup.
+  it('re-anchors an absolute file:// URL to the app-relative id', () => {
+    expect(
+      moduleIdFromUrl(
+        'file:///Users/me/project/app/templates/application.gjs?v=abc123',
+      ),
+    ).toBe('app/templates/application.gjs');
+  });
+
+  it('re-anchors an absolute file:// URL for an in-repo addon', () => {
+    expect(
+      moduleIdFromUrl(
+        'file:///Users/me/project/lib/my-addon/addon/routes/index.ts',
+      ),
+    ).toBe('addon/routes/index.ts');
+  });
+
+  it('leaves an already app-relative id untouched', () => {
+    expect(moduleIdFromUrl('app/services/store.js')).toBe(
+      'app/services/store.js',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `moduleIdFromUrl()` (fixed for browser `base`/https URLs in #509) still derives the wrong module id when the app is loaded outside of vite's own dev server - e.g. a custom Node ESM loader that resolves modules straight to on-disk `file://` URLs, with no server `base` to strip.
- In that case the id was left as the full OS path up to the project root (`Users/me/project/app/templates/...`) instead of `app/templates/...`, so `ViteHotReloadService`'s `startsWith('app/templates/')` check never matched and route/template-level HMR silently never fired, even though component-level HMR worked.
- Re-anchors the id to the nearest hot-reloadable directory (`app|addon/routes|routers|controllers|templates|services/...`) whenever it appears in the path, regardless of what precedes it on disk. This is a no-op for already-correct browser-derived ids.

## Test plan
- [x] `npx vitest run tests/setup-ember-hmr.test.ts` - new unit tests covering root-relative, non-root-base, absolute `file://` (app + in-repo addon), and already-normalized ids
- [x] `npx vitest run tests/hmr-transform.test.ts tests/hmr-optimize-deps.test.ts` - no regressions
- [x] `pnpm build` - builds cleanly