### PR TITLE
Support template-only components (TOC) in HMR

### DIFF
--- a/lib/hmr.ts
+++ b/lib/hmr.ts
@@ -178,11 +178,15 @@ export function hmr(enableViteHmrForModes: string[] = ['development']): Plugin {
     name: 'hmr-plugin',
     enforce: 'post',
     config(_config, env) {
-      // The per-component hot wrapper (see getHotComponent) imports these, but
-      // it is generated/served on demand, so it is never part of the static
-      // module graph Vite's dependency scanner crawls on the first pass.
-      // Without pre-declaring them, the browser requests them on boot, Vite
-      // discovers "new" deps and triggers a re-optimize + full page reload.
+      // The per-component hot wrapper (see getHotComponent) imports the first
+      // four of these, but it is generated/served on demand, so it is never
+      // part of the static module graph Vite's dependency scanner crawls on
+      // the first pass. `@ember/component/template-only` has the same
+      // problem for a different reason: it's injected by the template
+      // compiler into a template-only component's compiled output, which the
+      // scanner (source-only) never sees either. Without pre-declaring them,
+      // the browser requests them on boot, Vite discovers "new" deps and
+      // triggers a re-optimize + full page reload.
       //
       // We must use the Embroider-rewritten `ember-source/...` subpaths: the
       // bare `@glimmer/reference` etc. specifiers the wrapper writes cannot be
@@ -199,6 +203,7 @@ export function hmr(enableViteHmrForModes: string[] = ['development']): Plugin {
             'ember-source/@glimmer/runtime/index.js',
             'ember-source/@ember/destroyable/index.js',
             'ember-source/@glimmer/manager/index.js',
+            'ember-source/@ember/component/template-only.js',
           ],
         },
       };
@@ -570,7 +575,17 @@ export function hmr(enableViteHmrForModes: string[] = ['development']): Plugin {
             hotReloadStatements.push(`
   (async () => {
     const GlimmerComponent = (await import('@glimmer/component')).default;
-    if (${imp.local}.prototype instanceof GlimmerComponent) {
+    const { hasInternalComponentManager } = await import('@glimmer/manager');
+    // Class-based Glimmer components are functions, detected the cheap way
+    // via prototype chain. Template-only components (no backing class, e.g.
+    // a bare \`<template>\` export) are plain objects instead, so they have to
+    // be recognized by checking for a registered component manager - that
+    // also keeps helpers/modifiers (which use separate manager registries)
+    // out of this branch.
+    const isComponent = typeof ${imp.local} === 'function'
+      ? ${imp.local}.prototype instanceof GlimmerComponent
+      : typeof ${imp.local} === 'object' && ${imp.local} !== null && hasInternalComponentManager(${imp.local});
+    if (isComponent) {
       const c = await import('${virtualPath}');
       ${importVar}.${imp.local} = c.default;
       import.meta.hot.accept('${virtualPath}', (c) => {

--- a/tests/hmr-optimize-deps.test.ts
+++ b/tests/hmr-optimize-deps.test.ts
@@ -9,6 +9,12 @@ import { hmr } from '../lib/hmr';
 // boot, Vite discovers "new" deps and triggers a re-optimize + full page
 // reload.
 //
+// `@ember/component/template-only` has the same problem for a different
+// reason: it's injected by the template compiler into a template-only
+// component's (a bare `<template>` export, no backing class) compiled
+// output, so the scanner - which only sees pre-compile source - can't find
+// it either.
+//
 // The deps must be declared as the Embroider-rewritten `ember-source/...`
 // subpaths — the bare `@glimmer/reference` etc. specifiers the wrapper writes
 // cannot be resolved by optimizeDeps.include.
@@ -32,6 +38,7 @@ describe('hmr() optimizeDeps declaration', () => {
       'ember-source/@glimmer/runtime/index.js',
       'ember-source/@ember/destroyable/index.js',
       'ember-source/@glimmer/manager/index.js',
+      'ember-source/@ember/component/template-only.js',
     ]);
   });
 

--- a/tests/playground/hmr.test.ts
+++ b/tests/playground/hmr.test.ts
@@ -717,6 +717,72 @@ export default class DataService extends Service {
       },
     );
 
+    // A template-only component (`<template>...</template>` with no backing
+    // class) exports a TemplateOnlyComponentDefinition instance rather than a
+    // class extending @glimmer/component, so the wrapper's runtime check must
+    // not rely solely on `instanceof GlimmerComponent` or these imports are
+    // silently never hot-wrapped (and never even get an accept boundary),
+    // falling back to a full page reload.
+    test(
+      'should hmr a template-only component',
+      { timeout: 15 * 1000 },
+      async () => {
+        await editFile('./app/components/toc-component.gjs').setContent(`
+    <template>
+      <div class='toc-component'>toc v1</div>
+    </template>
+    `);
+
+        await editFile('./app/components/test-component.gjs').setContent(`
+    import Component from "@glimmer/component";
+    import { tracked } from '@glimmer/tracking';
+    import TocComponent from './toc-component.gjs';
+
+    export default class MyComponent extends Component {
+      @tracked count = 1;
+      <template>
+        <div class='hmr-state'>count: {{this.count}}</div>
+        <TocComponent />
+      </template>
+    }
+    `);
+
+        await waitForMessage('hot updated: /app/components/test-component.gjs');
+        let toc = await page.waitForSelector('.toc-component');
+        let tocContent = await toc.evaluate((el) => el.textContent);
+        expect(tocContent, tocContent).toContain('toc v1');
+
+        // a real page reload would clear this, so it also proves the update
+        // below stayed in-place instead of falling back to a full reload
+        await page.evaluate(() => {
+          (
+            globalThis as unknown as { __tocTestMarker: string }
+          ).__tocTestMarker = 'still-here';
+        });
+
+        await editFile('./app/components/toc-component.gjs').setContent(`
+    <template>
+      <div class='toc-component'>toc v2</div>
+    </template>
+    `);
+
+        await waitForMessage(
+          'hot updated: /app/components/toc-component.gjs via /app/components/test-component.gjs',
+        );
+
+        toc = await page.waitForSelector('.toc-component');
+        tocContent = await toc.evaluate((el) => el.textContent);
+        expect(tocContent, tocContent).toContain('toc v2');
+
+        const marker = await page.evaluate(
+          () =>
+            (globalThis as unknown as { __tocTestMarker?: string })
+              .__tocTestMarker,
+        );
+        expect(marker).toBe('still-here');
+      },
+    );
+
     // must stay the last test: it tears down the shared vite instance and
     // boots a new one with a non-root `base`
     test(


### PR DESCRIPTION
## Summary
- Template-only components (a bare `<template>...</template>` export with no backing class) weren't hot-reloadable: the generated wrapper only swapped in the HMR-capable virtual component when `local.prototype instanceof GlimmerComponent`, which is always `false` for a `TemplateOnlyComponentDefinition` instance. That meant the import was silently never wrapped and never even got an `import.meta.hot.accept` boundary, so editing a TOC fell back to a full page reload.
- `lib/hmr.ts`: broaden the runtime detection to use `hasInternalComponentManager` from `@glimmer/manager` for non-function import values, alongside the existing `instanceof GlimmerComponent` check for class-based components. Helpers/modifiers are unaffected since they're registered in separate manager maps.
- Also declare `ember-source/@ember/component/template-only.js` in `optimizeDeps.include` — it's injected by the template compiler into a TOC's compiled output, which Vite's dependency scanner (source-only) can't see, causing a duplicate-module-instance failure ("did not have a component manager associated with it") the first time a TOC is referenced. Same root cause the existing wrapper-dep entries in that list work around.

## Test plan
- [x] Added a failing-first e2e test (`should hmr a template-only component`) in `tests/playground/hmr.test.ts`: imports a bare `<template>` component, edits it, and asserts the update lands in place (via a `window` marker that a full reload would clear) with no `page reload` message.
- [x] Verified the new test fails against unmodified `main` with the exact runtime error described above, and passes with the fix.
- [x] Full playground e2e suite (`REUSE=1 pnpm exec vitest run tests/playground/hmr.test.ts`): 11/12 pass; the one failure (`should hmr services with state preservation`) reproduces identically on unmodified `main` — pre-existing flake, unrelated to this change.
- [x] Updated `tests/hmr-optimize-deps.test.ts` for the new `optimizeDeps.include` entry.
- [x] `pnpm run build` and unit test files (`hmr-transform`, `babel-plugin`, `setup-ember-hmr`, `hmr-optimize-deps`, `service-hmr`) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)