### PR TITLE
Fix service HMR duplicate-module race on ember-source 7.1+

### DIFF
--- a/lib/babel-plugin.ts
+++ b/lib/babel-plugin.ts
@@ -281,11 +281,55 @@ export default function hotReplaceAst(babel: typeof Babel): PluginObj {
 
         const originalClassName = classIdentifier.name;
         const proxyClassName = `${originalClassName}HmrProxy`;
-        const implVarName = `_${originalClassName}Impl`;
-        const proxyVarName = `_${originalClassName}Proxy`;
 
         // Keep the original class as-is, just remove it from export
         // We'll add it back as a non-exported class
+
+        const babelTemplate = (babel as typeof import('@babel/core')).template;
+
+        // The live proxy instance and the latest accepted implementation must
+        // live on `import.meta.hot.data`, not in a module-scope `let`: Vite
+        // guarantees that object (and only that object) survives across a
+        // module's hot re-evaluations. A component's `@service` injection can
+        // end up constructing the proxy against a *later* re-evaluation of
+        // this module than the one whose `import.meta.hot.accept` closure
+        // captured a module-scope variable — the closure and the constructor
+        // would then silently operate on two disconnected variable bindings
+        // (a duplicate-module symptom), and the HMR swap would never reach
+        // the instance actually rendered.
+        const ctorBody = babelTemplate.statements(
+          `
+            super(...args);
+            this._owner = args[0];
+            const Impl = (import.meta.hot && import.meta.hot.data._impl) || ${proxyClassName}.Impl;
+            this._delegate = new Impl(this._owner);
+            if (import.meta.hot) {
+              import.meta.hot.data._proxy = this;
+            }
+            return new Proxy(this, {
+              get(target, prop) {
+                if (prop === '_delegate') {
+                  return target._delegate;
+                }
+                return target._delegate[prop];
+              },
+              set(target, prop, value) {
+                target._delegate[prop] = value;
+                return true;
+              },
+            });
+          `,
+        )() as BabelTypesNamespace.Statement[];
+
+        const willDestroyBody = babelTemplate.statements(
+          `
+            super.willDestroy();
+            this._delegate.willDestroy();
+            if (import.meta.hot && import.meta.hot.data._proxy === this) {
+              import.meta.hot.data._proxy = undefined;
+            }
+          `,
+        )() as BabelTypesNamespace.Statement[];
 
         // Create the HMR proxy service class
         const proxyClass = t.classDeclaration(
@@ -310,165 +354,20 @@ export default function hotReplaceAst(babel: typeof Babel): PluginObj {
               false,
               false,
             ),
-            // constructor
             t.classMethod(
               'constructor',
               t.identifier('constructor'),
               [t.restElement(t.identifier('args'))],
-              t.blockStatement([
-                t.expressionStatement(
-                  t.callExpression(t.super(), [
-                    t.spreadElement(t.identifier('args')),
-                  ]),
-                ),
-                // Store owner for HMR reloads
-                t.expressionStatement(
-                  t.assignmentExpression(
-                    '=',
-                    t.memberExpression(
-                      t.thisExpression(),
-                      t.identifier('_owner')
-                    ),
-                    t.memberExpression(
-                      t.identifier('args'),
-                      t.numericLiteral(0),
-                      true
-                    )
-                  )
-                ),
-                // Initialize delegate with owner
-                t.expressionStatement(
-                  t.assignmentExpression(
-                    '=',
-                    t.memberExpression(
-                      t.thisExpression(),
-                      t.identifier('_delegate')
-                    ),
-                    t.newExpression(t.identifier(implVarName), [
-                      t.memberExpression(
-                        t.thisExpression(),
-                        t.identifier('_owner')
-                      )
-                    ])
-                  )
-                ),
-                t.ifStatement(
-                  t.unaryExpression('!', t.identifier(proxyVarName)),
-                  t.blockStatement([
-                    t.expressionStatement(
-                      t.assignmentExpression(
-                        '=',
-                        t.identifier(proxyVarName),
-                        t.thisExpression(),
-                      ),
-                    ),
-                  ]),
-                ),
-                t.returnStatement(
-                  t.newExpression(t.identifier('Proxy'), [
-                    t.thisExpression(),
-                    t.objectExpression([
-                      t.objectMethod(
-                        'method',
-                        t.identifier('get'),
-                        [t.identifier('target'), t.identifier('prop')],
-                        t.blockStatement([
-                          t.ifStatement(
-                            t.binaryExpression(
-                              '===',
-                              t.identifier('prop'),
-                              t.stringLiteral('_delegate'),
-                            ),
-                            t.returnStatement(
-                              t.memberExpression(
-                                t.identifier('target'),
-                                t.identifier('_delegate'),
-                              ),
-                            ),
-                          ),
-                          t.returnStatement(
-                            t.memberExpression(
-                              t.memberExpression(
-                                t.identifier('target'),
-                                t.identifier('_delegate'),
-                              ),
-                              t.identifier('prop'),
-                              true,
-                            ),
-                          ),
-                        ]),
-                      ),
-                      t.objectMethod(
-                        'method',
-                        t.identifier('set'),
-                        [
-                          t.identifier('target'),
-                          t.identifier('prop'),
-                          t.identifier('value'),
-                        ],
-                        t.blockStatement([
-                          t.expressionStatement(
-                            t.assignmentExpression(
-                              '=',
-                              t.memberExpression(
-                                t.memberExpression(
-                                  t.identifier('target'),
-                                  t.identifier('_delegate'),
-                                ),
-                                t.identifier('prop'),
-                                true,
-                              ),
-                              t.identifier('value'),
-                            ),
-                          ),
-                          t.returnStatement(t.booleanLiteral(true)),
-                        ]),
-                      ),
-                    ]),
-                  ]),
-                ),
-              ]),
+              t.blockStatement(ctorBody),
             ),
-            // willDestroy
             t.classMethod(
               'method',
               t.identifier('willDestroy'),
               [],
-              t.blockStatement([
-                t.expressionStatement(
-                  t.callExpression(
-                    t.memberExpression(t.super(), t.identifier('willDestroy')),
-                    [],
-                  ),
-                ),
-                t.expressionStatement(
-                  t.callExpression(
-                    t.memberExpression(
-                      t.memberExpression(
-                        t.thisExpression(),
-                        t.identifier('_delegate'),
-                      ),
-                      t.identifier('willDestroy'),
-                    ),
-                    [],
-                  ),
-                ),
-              ]),
+              t.blockStatement(willDestroyBody),
             ),
           ]),
         );
-
-        // Create variable declarations with unique names to avoid conflicts
-        const currentImplDeclaration = t.variableDeclaration('let', [
-          t.variableDeclarator(
-            t.identifier(implVarName),
-            t.identifier(originalClassName),
-          ),
-        ]);
-
-        const currentProxyDeclaration = t.variableDeclaration('let', [
-          t.variableDeclarator(t.identifier(proxyVarName), t.nullLiteral()),
-        ]);
 
         // For Case 1 (inline class), we need to keep the class as non-exported
         // For Case 2 (separate declaration), the class already exists, so we don't recreate it
@@ -482,18 +381,14 @@ export default function hotReplaceAst(babel: typeof Babel): PluginObj {
           );
 
           // Replace the export with all the necessary declarations
-          // IMPORTANT: Class must be declared BEFORE the variables that reference it
+          // IMPORTANT: Class must be declared BEFORE the proxy class that references it
           path.replaceWithMultiple([
             originalClass, // The original class (no longer exported) - MUST BE FIRST
-            currentImplDeclaration,
-            currentProxyDeclaration,
             t.exportDefaultDeclaration(proxyClass), // Export the proxy class
           ]);
         } else {
           // Case 2: Separate declaration - class already exists, just replace the export
           path.replaceWithMultiple([
-            currentImplDeclaration,
-            currentProxyDeclaration,
             t.exportDefaultDeclaration(proxyClass), // Export the proxy class
           ]);
         }
@@ -503,23 +398,28 @@ export default function hotReplaceAst(babel: typeof Babel): PluginObj {
           const hmrCode = `
             if (import.meta.hot) {
               import.meta.hot.accept((newModule) => {
-                if (import.meta.hot.data._hotReload && newModule?.default?.Impl) {
-                  import.meta.hot.data._hotReload(newModule.default.Impl);
-                }
-              });
-              
-              import.meta.hot.data._hotReload = import.meta.hot.data._hotReload || function(NewImpl) {
-                // Skip reload if no instance has been created yet
-                if (!${proxyVarName}) {
-                  ${implVarName} = NewImpl;
+                const NewImpl = newModule?.default?.Impl;
+                if (!NewImpl) {
                   return;
                 }
-                
-                const oldDelegate = ${proxyVarName}._delegate;
-                ${implVarName} = NewImpl;
-                const newDelegate = new ${implVarName}(${proxyVarName}._owner);
-                ${proxyVarName}._delegate = newDelegate;
-                
+
+                // Remember the latest accepted implementation so a proxy
+                // constructed *after* this update (its instantiation raced
+                // behind the HMR swap) still picks up the new class instead
+                // of the stale one captured at module-evaluation time.
+                import.meta.hot.data._impl = NewImpl;
+
+                const proxy = import.meta.hot.data._proxy;
+                if (!proxy) {
+                  // No instance has been created yet; the next construction
+                  // will read import.meta.hot.data._impl above.
+                  return;
+                }
+
+                const oldDelegate = proxy._delegate;
+                const newDelegate = new NewImpl(proxy._owner);
+                proxy._delegate = newDelegate;
+
                 // Sync state from old to new while keeping new implementation defaults
                 for (const key in oldDelegate) {
                   const descriptor =
@@ -528,17 +428,17 @@ export default function hotReplaceAst(babel: typeof Babel): PluginObj {
                   const hasOwnDefault = Object.prototype.hasOwnProperty.call(newDelegate, key);
                   const currentValue = newDelegate[key];
                   const previousValue = oldDelegate[key];
-                  
+
                   // Skip Service instances - they should not be synced
                   if (previousValue instanceof Service) {
                     continue;
                   }
-                  
+
                   // Skip Function properties - they should not be synced
                   if (typeof previousValue === 'function') {
                     continue;
                   }
-                  
+
                   const shouldSync =
                     !!descriptor &&
                     (descriptor.writable || descriptor.set || Object.prototype.hasOwnProperty.call(oldDelegate, key)) &&
@@ -554,11 +454,11 @@ export default function hotReplaceAst(babel: typeof Babel): PluginObj {
                 }
 
                 newDelegate._hmrAccepted?.(oldDelegate);
-                
+
                 if (oldDelegate.willDestroy) {
                   oldDelegate.willDestroy();
                 }
-              };
+              });
             }
           `;
 

--- a/tests/service-hmr.test.js
+++ b/tests/service-hmr.test.js
@@ -48,10 +48,9 @@ export default TestService;
     // Verify the transformation includes key HMR components
     expect(result.code).toContain('TestServiceHmrProxy');
     expect(result.code).toContain('class TestService extends');
-    expect(result.code).toContain('let _TestServiceImpl');
-    expect(result.code).toContain('let _TestServiceProxy');
+    expect(result.code).toContain('import.meta.hot.data._proxy');
+    expect(result.code).toContain('import.meta.hot.data._impl');
     expect(result.code).toContain('import.meta.hot');
-    expect(result.code).toContain('_hotReload');
     expect(result.code).toContain('new Proxy');
     expect(result.code).toContain('static Impl');
     expect(result.code).toContain('_delegate');
@@ -86,8 +85,6 @@ export default TestService;
           this.message = 'Hello from test service';
         }
       }
-      let _TestServiceImpl = TestService;
-      let _TestServiceProxy = null;
       export default class TestServiceHmrProxy extends Service {
         static {
           [_init__delegate] = _applyDecs2203R(this, [[tracked, 0, "_delegate"]], []).e;
@@ -97,13 +94,16 @@ export default TestService;
         constructor(...args) {
           super(...args);
           this._owner = args[0];
-          this._delegate = new _TestServiceImpl(this._owner);
-          if (!_TestServiceProxy) {
-            _TestServiceProxy = this;
+          const Impl = import.meta.hot && import.meta.hot.data._impl || TestServiceHmrProxy.Impl;
+          this._delegate = new Impl(this._owner);
+          if (import.meta.hot) {
+            import.meta.hot.data._proxy = this;
           }
           return new Proxy(this, {
             get(target, prop) {
-              if (prop === "_delegate") return target._delegate;
+              if (prop === '_delegate') {
+                return target._delegate;
+              }
               return target._delegate[prop];
             },
             set(target, prop, value) {
@@ -115,23 +115,25 @@ export default TestService;
         willDestroy() {
           super.willDestroy();
           this._delegate.willDestroy();
+          if (import.meta.hot && import.meta.hot.data._proxy === this) {
+            import.meta.hot.data._proxy = undefined;
+          }
         }
       }
       if (import.meta.hot) {
         import.meta.hot.accept(newModule => {
-          if (import.meta.hot.data._hotReload && newModule?.default?.Impl) {
-            import.meta.hot.data._hotReload(newModule.default.Impl);
-          }
-        });
-        import.meta.hot.data._hotReload = import.meta.hot.data._hotReload || function (NewImpl) {
-          if (!_TestServiceProxy) {
-            _TestServiceImpl = NewImpl;
+          const NewImpl = newModule?.default?.Impl;
+          if (!NewImpl) {
             return;
           }
-          const oldDelegate = _TestServiceProxy._delegate;
-          _TestServiceImpl = NewImpl;
-          const newDelegate = new _TestServiceImpl(_TestServiceProxy._owner);
-          _TestServiceProxy._delegate = newDelegate;
+          import.meta.hot.data._impl = NewImpl;
+          const proxy = import.meta.hot.data._proxy;
+          if (!proxy) {
+            return;
+          }
+          const oldDelegate = proxy._delegate;
+          const newDelegate = new NewImpl(proxy._owner);
+          proxy._delegate = newDelegate;
           for (const key in oldDelegate) {
             const descriptor = Object.getOwnPropertyDescriptor(oldDelegate, key) || Object.getOwnPropertyDescriptor(Object.getPrototypeOf(oldDelegate), key);
             const hasOwnDefault = Object.prototype.hasOwnProperty.call(newDelegate, key);
@@ -154,7 +156,7 @@ export default TestService;
           if (oldDelegate.willDestroy) {
             oldDelegate.willDestroy();
           }
-        };
+        });
       }"
     `);
   });
@@ -239,7 +241,6 @@ export default class SimpleService extends Service {
     // Should still contain HMR transformation
     expect(result.code).toContain('SimpleServiceHmrProxy');
     expect(result.code).toContain('class SimpleService extends');
-    expect(result.code).toContain('let _SimpleServiceImpl');
     expect(result.code).toContain('import.meta.hot');
   });
 
@@ -304,8 +305,6 @@ export default class DataService extends Service {
           _initClass();
         }
       }
-      let _DataServiceImpl = _DataService;
-      let _DataServiceProxy = null;
       export default class DataServiceHmrProxy extends Service {
         static {
           [_init__delegate] = _applyDecs2203R(this, [[tracked, 0, "_delegate"]], []).e;
@@ -315,13 +314,16 @@ export default class DataService extends Service {
         constructor(...args) {
           super(...args);
           this._owner = args[0];
-          this._delegate = new _DataServiceImpl(this._owner);
-          if (!_DataServiceProxy) {
-            _DataServiceProxy = this;
+          const Impl = import.meta.hot && import.meta.hot.data._impl || DataServiceHmrProxy.Impl;
+          this._delegate = new Impl(this._owner);
+          if (import.meta.hot) {
+            import.meta.hot.data._proxy = this;
           }
           return new Proxy(this, {
             get(target, prop) {
-              if (prop === "_delegate") return target._delegate;
+              if (prop === '_delegate') {
+                return target._delegate;
+              }
               return target._delegate[prop];
             },
             set(target, prop, value) {
@@ -333,23 +335,25 @@ export default class DataService extends Service {
         willDestroy() {
           super.willDestroy();
           this._delegate.willDestroy();
+          if (import.meta.hot && import.meta.hot.data._proxy === this) {
+            import.meta.hot.data._proxy = undefined;
+          }
         }
       }
       if (import.meta.hot) {
         import.meta.hot.accept(newModule => {
-          if (import.meta.hot.data._hotReload && newModule?.default?.Impl) {
-            import.meta.hot.data._hotReload(newModule.default.Impl);
-          }
-        });
-        import.meta.hot.data._hotReload = import.meta.hot.data._hotReload || function (NewImpl) {
-          if (!_DataServiceProxy) {
-            _DataServiceImpl = NewImpl;
+          const NewImpl = newModule?.default?.Impl;
+          if (!NewImpl) {
             return;
           }
-          const oldDelegate = _DataServiceProxy._delegate;
-          _DataServiceImpl = NewImpl;
-          const newDelegate = new _DataServiceImpl(_DataServiceProxy._owner);
-          _DataServiceProxy._delegate = newDelegate;
+          import.meta.hot.data._impl = NewImpl;
+          const proxy = import.meta.hot.data._proxy;
+          if (!proxy) {
+            return;
+          }
+          const oldDelegate = proxy._delegate;
+          const newDelegate = new NewImpl(proxy._owner);
+          proxy._delegate = newDelegate;
           for (const key in oldDelegate) {
             const descriptor = Object.getOwnPropertyDescriptor(oldDelegate, key) || Object.getOwnPropertyDescriptor(Object.getPrototypeOf(oldDelegate), key);
             const hasOwnDefault = Object.prototype.hasOwnProperty.call(newDelegate, key);
@@ -372,7 +376,7 @@ export default class DataService extends Service {
           if (oldDelegate.willDestroy) {
             oldDelegate.willDestroy();
           }
-        };
+        });
       }"
     `);
   });
@@ -420,10 +424,9 @@ export default TestService;
     // Verify the transformation includes key HMR components
     expect(result.code).toContain('TestServiceHmrProxy');
     expect(result.code).toContain('class TestService extends');
-    expect(result.code).toContain('let _TestServiceImpl');
-    expect(result.code).toContain('let _TestServiceProxy');
+    expect(result.code).toContain('import.meta.hot.data._proxy');
+    expect(result.code).toContain('import.meta.hot.data._impl');
     expect(result.code).toContain('import.meta.hot');
-    expect(result.code).toContain('_hotReload');
     expect(result.code).toContain('new Proxy');
     expect(result.code).toContain('static Impl');
     expect(result.code).toContain('_delegate');


### PR DESCRIPTION
## Summary

Fixes a real regression triggered by ember-source 7.1's removal of internal
barrel-file imports (upstream: emberjs/ember.js#21350, #21352): the
generated **service** HMR proxy could end up with two disconnected live
copies of the same logical module, silently breaking hot-reload for
services from then on.

## Root cause

The proxy stored its live instance and current implementation class in
module-scope `let` variables. The `import.meta.hot.accept` callback
persisted its closure across hot updates via
`import.meta.hot.data._hotReload = import.meta.hot.data._hotReload || fn`,
so it kept referencing whichever module scope evaluated *first*.

If a hot update lands between a service module's first evaluation and the
first time a component actually injects/instantiates that service (which
can now happen with ember-source 7.1+'s changed internal import timing),
the constructor that finally runs belongs to a *later* re-evaluation of the
module and sets *that* scope's own `_XProxy` binding — a different
variable than the one the earlier `accept` closure captured. The two
halves of the wiring end up pointing at disconnected variable bindings
(effectively two live copies of the same module), so the hot-swap silently
no-ops forever.

Confirmed with debug instrumentation: `_hotReload` was invoked with
`hasProxyVar: false` even after the service had already been constructed
elsewhere, because the constructor ran in a different module scope.

## Fix

Move all HMR bookkeeping onto `import.meta.hot.data`, which Vite
guarantees is the *same* object across a module's re-evaluations. The
`accept` handler now reads `import.meta.hot.data._proxy` / `._impl` fresh
on every invocation instead of closing over a module-scope variable, so it
can't go stale regardless of which re-evaluation ends up constructing the
live instance.

## Verification

- `should hmr services with state preservation` (e2e playground suite)
  reproduced the failure deterministically against ember-source 7.1.0 with
  a cold Vite dep cache (before the fix), and passes consistently across
  repeated cold runs after the fix.
- Full playground e2e suite (12 tests) and full unit suite (40 tests) pass.
- `tests/service-hmr.test.js` updated: assertions/inline snapshots now
  reflect the `import.meta.hot.data`-based design instead of the old
  module-scope `let _XImpl`/`let _XProxy` variables.

## Test plan

- [x] `pnpm build`
- [x] `pnpm exec vitest run tests/service-hmr.test.js`
- [x] `REUSE=1 pnpm exec vitest run tests/playground/hmr.test.ts` (cold `.vite` cache, ember-source 7.1.0, x3)
- [x] `pnpm exec vitest run` (full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)