### PR TITLE
Fix (has-block) always true for named blocks in HMR-wrapped components

### DIFF
--- a/lib/hmr.ts
+++ b/lib/hmr.ts
@@ -9,26 +9,55 @@ import { readFile } from 'fs/promises';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+// Above this many distinct named blocks, fall back to forwarding all of them
+// unconditionally rather than generating an exponential number of branches
+// (see generateInvocations below for why branching is needed at all).
+const MAX_COMBINATORIAL_YIELDS = 8;
+
+function blockTag(y: string) {
+  return `<:${y} as |a b c d e f g h i j k l|>{{yield a b c d e f g h i j k l to='${y}'}}</:${y}>`;
+}
+
+function invocation(selected: string[]) {
+  if (!selected.length) {
+    return `<this.curried @__hot__={{this.hot}} ...attributes />`;
+  }
+  return `<this.curried @__hot__={{this.hot}} ...attributes>${selected.map(blockTag).join('\n')}</this.curried>`;
+}
+
+// Glimmer determines a target component's `(has-block "y")` purely from
+// whether a `<:y>` named block tag is structurally present on the
+// invocation, not from whether that block's content renders anything, and
+// named block tags cannot be nested inside `{{#if}}` (a "named block nested
+// in a normal block" compile error). So a per-block `{{#if (has-block 'y')}}
+// <:y>...</:y>{{/if}}` inside a single invocation can't work — instead this
+// recursively branches on `(has-block y)` for each known named block to
+// build one fully static invocation per combination of blocks the caller
+// actually passed, so blocks not passed are truly absent rather than merely
+// empty (see #531).
+function generateInvocations(remaining: string[], selected: string[]): string {
+  if (!remaining.length) {
+    return invocation(selected);
+  }
+  const [y, ...rest] = remaining;
+  return `{{#if (has-block '${y}')}}${generateInvocations(rest, [...selected, y])}{{else}}${generateInvocations(rest, selected)}{{/if}}`;
+}
+
 function generateContent(yields: string[]) {
   if (!yields.includes('default')) {
     yields.push('default');
   }
-  let all = yields.map((y) => `(has-block '${y}')`).join(' ');
-  let str = '';
-  for (const y of yields) {
-    str += `
-        <:${y} as |a b c d e f g h i j k l|>{{yield a b c d e f g h i j k l to='${y}'}}</:${y}>
-    `;
-  }
-  return `
+  if (yields.length > MAX_COMBINATORIAL_YIELDS) {
+    let all = yields.map((y) => `(has-block '${y}')`).join(' ');
+    return `
     {{#if (notAny ${all})}}
         <this.curried @__hot__={{this.hot}} ...attributes />
     {{else}}
-        <this.curried @__hot__={{this.hot}} ...attributes >
-        ${str}
-        </this.curried>
+        ${invocation(yields)}
     {{/if}}
   `;
+  }
+  return generateInvocations(yields, []);
 }
 
 const getHotComponent = (imp: string, specifier: string, yields: string[]) => `

--- a/tests/playground/hmr.test.ts
+++ b/tests/playground/hmr.test.ts
@@ -373,6 +373,45 @@ describe(
       await page.waitForSelector('.yields');
     });
 
+    test('should respect (has-block) for a named block the caller did not pass', async () => {
+      await editFile('./app/components/named-block-card.hbs').setContent(`
+    <div class='named-block-card-default'>{{yield}}</div>
+    {{#if (has-block "footer")}}
+      <div class='named-block-card-footer'>{{yield to='footer'}}</div>
+    {{/if}}
+    `);
+
+      // consumer only supplies the default block, never :footer, so the
+      // footer div must not be rendered even though the wrapped component
+      // knows about a 'footer' named block from prior HMR analysis
+      await editFile('./app/templates/application.hbs').setContent(`
+        <NamedBlockCard>default only</NamedBlockCard>`);
+      await waitForMessage('hmr update /app/templates/application.hbs');
+      await waitForMessage('hot updated: /app/templates/application.hbs');
+
+      const defaultBlock = await page.waitForSelector(
+        '.named-block-card-default',
+      );
+      const defaultContent = await defaultBlock.evaluate(
+        (el) => el.textContent,
+      );
+      expect(defaultContent, defaultContent).toContain('default only');
+
+      const footerBlock = await page.$('.named-block-card-footer');
+      expect(footerBlock).toBeNull();
+
+      // restore TestComponent in the application template, later tests rely on
+      // it being rendered
+      await editFile('./app/templates/application.hbs').setContent(`
+        <TestComponent>
+            <:default as |txt|>{{txt}}</:default>
+            <:named as |txt|>{{txt}}</:named>
+        </TestComponent>`);
+      await waitForMessage('hmr update /app/templates/application.hbs');
+      await waitForMessage('hot updated: /app/templates/application.hbs');
+      await page.waitForSelector('.yields');
+    });
+
     test('should hmr with state', { timeout: 10 * 1000 }, async () => {
       await editFile('./app/components/foo-component.gjs').setContent(`
     import Component from "@glimmer/component";


### PR DESCRIPTION
## Summary
- `HotComponent` (the shadow component ember-vite-hmr wraps HMR'd components in) forwarded every named block it had statically detected on a target component to that target unconditionally, regardless of whether the actual caller passed it. Since Glimmer determines `(has-block "y")` purely from whether a `<:y>` named block tag is structurally present on the invocation (not from whether the block renders anything), this made `(has-block "footer")` always true inside the wrapped component whenever `footer` was a known named block — so `{{#if (has-block "footer")}}` blocks rendered even when the consumer never supplied a `:footer` block.
- Named block tags can't be conditionally nested inside `{{#if}}` within a single component invocation (Glimmer raises `Unexpected named block nested in a normal block`), so the fix generates one fully static invocation per combination of blocks the caller actually passed, selected via nested `{{#if (has-block y)}}` branches. Falls back to the old unconditional-forwarding behavior only when a component has more than 8 distinct named blocks, to avoid an exponential blowup in template size for a case that shouldn't occur in practice.

Fixes #531

## Test plan
- [x] Added a regression test (`should respect (has-block) for a named block the caller did not pass`) in `tests/playground/hmr.test.ts` using a template-only component with `{{#if (has-block "footer")}}`, asserting the footer element is absent when the consumer doesn't supply a `:footer` block.
- [x] `pnpm build:lib`
- [x] Full playground e2e suite (`vitest run tests/playground/hmr.test.ts`) — all 13 tests pass, including the pre-existing named-blocks regression test from #500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)